### PR TITLE
GraphQL types

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -61,8 +61,9 @@ export default defineConfig({
               { text: 'mux:mirror', link: '/commands/mux-mirror' },
             ],
           },
-          { text: 'Configuration', link: '/configuration' },
+          { text: 'GraphQL Types', link: '/graphql' },
           { text: 'Secure Playback', link: '/secure-playback' },
+          { text: 'Configuration', link: '/configuration' },
           { text: 'Events', link: '/events' },
         ]
       }

--- a/docs/display.md
+++ b/docs/display.md
@@ -48,6 +48,12 @@ Learn more about the [available Antlers tags](/tags).
 ></mux-player>
 ```
 
+:::
+
+## Headless Frontends
+
+For headless setups, the addon exposes custom [GraphQL Types](/graphql) you can query.
+
 ## Secure Playback
 
 By default, videos uploaded by this addon are public and can be watched without restrictions. If

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,0 +1,64 @@
+# GraphQL Types
+
+Any Mux data available in the [Antlers tags](./tags/) can also be queried via GraphQL.
+
+## Example
+
+Assuming you've added a [mirror field](/uploading/) called `mux` to your default asset container
+blueprint, you can query Mux data from the existing fieldname at `mux`. In your frontend, you can
+plug the returned data into  one of the official [Mux video components](/display#video-components).
+
+::: code-group
+
+```graphql [GraphQL Query]
+{
+  asset: asset(id: "assets::video.mp4") {
+    path
+    ... on Asset_Assets {
+      mux {
+        playback_id
+        thumbnail
+      }
+    }
+  }
+}
+```
+
+```json [JSON Result]
+{
+  "data": {
+    "asset": {
+      "id": "assets::video.mp4",
+      "path": "video.mp4",
+      "mux": {
+        "playback_id": "02G1uw5SpNCrPMwiqfyNY4RkOWff4O7DCohToTqcZXH8",
+        "thumbnail": "https://image.mux.com/02G1uw5SpNCrPMwiqfyNY4RkOWff4O7DCohToTqcZXH8/thumbnail.jpg",
+      }
+    }
+  }
+}
+```
+
+```html [Frontend Display]
+<mux-video
+  :playback-id="mux.playback_id"
+  :poster="mux.thumbnail"
+  width="1920"
+  height="1080"
+></mux-video>
+```
+
+:::
+
+## Available subfields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| **`mux_id`** | `string` | Mux asset id |
+| **`playback_id`** | `MuxPlaybackId` | Playback id used for streaming, defaults to public |
+| **`playback_ids`** | `MuxPlaybackId[]` | All available playback ids for this asset in case multiple exist |
+| **`playback_url`** | `string` | Playback url used for streaming |
+| **`playback_token`** | `string` | Signed playback token used for secure streaming |
+| **`thumbnail`** | `string` | Thumbnail image url |
+| **`gif`** | `string` | Animated gif url |
+| **`placeholder`** | `string` | Small blurry placeholder image data uri |

--- a/src/Data/MuxPlaybackId.php
+++ b/src/Data/MuxPlaybackId.php
@@ -5,8 +5,9 @@ namespace Daun\StatamicMux\Data;
 use Daun\StatamicMux\Mux\Enums\MuxPlaybackPolicy;
 use Illuminate\Contracts\Support\Arrayable;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
+use Stringable;
 
-class MuxPlaybackId implements Arrayable
+class MuxPlaybackId implements Stringable, Arrayable
 {
     use FluentlyGetsAndSets;
 
@@ -55,5 +56,10 @@ class MuxPlaybackId implements Arrayable
             'id' => $this->id,
             'policy' => $this->policy,
         ];
+    }
+
+    public function __toString(): string
+    {
+        return $this->id;
     }
 }

--- a/src/Fieldtypes/MuxMirrorFieldtype.php
+++ b/src/Fieldtypes/MuxMirrorFieldtype.php
@@ -3,8 +3,11 @@
 namespace Daun\StatamicMux\Fieldtypes;
 
 use Daun\StatamicMux\Data\MuxAsset;
+use Daun\StatamicMux\GraphQL\MuxMirrorType;
+use Daun\StatamicMux\GraphQL\MuxPlaybackIdType;
 use Daun\StatamicMux\Jobs\CreateMuxAssetJob;
 use Statamic\Assets\Asset;
+use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 
 class MuxMirrorFieldtype extends Fieldtype
@@ -80,5 +83,16 @@ class MuxMirrorFieldtype extends Fieldtype
         } else {
             return $value;
         }
+    }
+
+    public function toGqlType()
+    {
+        return GraphQL::type(MuxMirrorType::NAME);
+    }
+
+    public function addGqlTypes()
+    {
+        GraphQL::addType(MuxMirrorType::class);
+        GraphQL::addType(MuxPlaybackIdType::class);
     }
 }

--- a/src/GraphQL/MuxMirrorType.php
+++ b/src/GraphQL/MuxMirrorType.php
@@ -42,7 +42,7 @@ class MuxMirrorType extends \Rebing\GraphQL\Support\Type
     public function fields(): array
     {
         return [
-            'id' => [
+            'mux_id' => [
                 'type' => GraphQL::string(),
                 'description' => 'Mux asset ID',
                 'resolve' => fn (MuxAsset $item) => $item->augmentedValue('id'),

--- a/src/GraphQL/MuxMirrorType.php
+++ b/src/GraphQL/MuxMirrorType.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Daun\StatamicMux\GraphQL;
+
+use Daun\StatamicMux\Data\MuxAsset;
+use Daun\StatamicMux\Facades\Mux;
+use Daun\StatamicMux\Mux\Enums\MuxPlaybackPolicy;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Types\JsonArgument;
+
+class MuxMirrorType extends \Rebing\GraphQL\Support\Type
+{
+    const NAME = 'MuxMirror';
+
+    protected $attributes = [
+        'name' => self::NAME,
+        'description' => 'Video uploaded to and encoded by Mux',
+    ];
+
+    protected function playbackPolicyArgs(): array
+    {
+        return [
+            'policy' => [
+                'type' => GraphQL::string(),
+                'description' => 'Playback policy to filter by: "public" or "signed"',
+            ],
+        ];
+    }
+
+    protected function paramArgs(?string $name = 'url'): array
+    {
+        return [
+            'params' => [
+                'type' => GraphQL::type(JsonArgument::NAME),
+                'description' => "Additional parameters to include when generating the {$name}",
+            ],
+        ];
+    }
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => GraphQL::string(),
+                'description' => 'Mux asset ID',
+                'resolve' => fn (MuxAsset $item) => $item->augmentedValue('id'),
+            ],
+            'playback_ids' => [
+                'type' => GraphQL::listOf(GraphQL::type(MuxPlaybackIdType::NAME)),
+                'description' => 'All available Mux playback ids for this asset',
+                'resolve' => fn (MuxAsset $item) => $item->playbackIds(),
+            ],
+            'playback_id' => [
+                'type' => GraphQL::type(MuxPlaybackIdType::NAME),
+                'description' => 'Mux playback id used for streaming the video. Defaults to the first found `public` playback id, unless filtered by `policy` argument',
+                'args' => $this->playbackPolicyArgs(),
+                'resolve' => function (MuxAsset $item, array $args) {
+                    return $item->playbackId($this->getPolicy($args));
+                },
+            ],
+            'playback_url' => [
+                'type' => GraphQL::string(),
+                'description' => 'Playback url used for streaming the video',
+                'args' => [
+                    ...$this->playbackPolicyArgs(),
+                    ...$this->paramArgs('playback url'),
+                ],
+                'resolve' => function (MuxAsset $item, array $args) {
+                    return Mux::getPlaybackUrl($item->playbackId($this->getPolicy($args)), params: $args['params'] ?? []);
+                },
+            ],
+            'playback_token' => [
+                'type' => GraphQL::string(),
+                'description' => 'Signed token used for private video playback',
+                'args' => [
+                    ...$this->playbackPolicyArgs(),
+                    ...$this->paramArgs('signed playback url'),
+                ],
+                'resolve' => function (MuxAsset $item, array $args) {
+                    return Mux::getPlaybackToken($item->playbackId($this->getPolicy($args)), params: $args['params'] ?? []);
+                },
+            ],
+            'thumbnail' => [
+                'type' => GraphQL::string(),
+                'description' => 'Url of a thumbnail image representing the video',
+                'args' => [
+                    ...$this->playbackPolicyArgs(),
+                    ...$this->paramArgs('thumbnail url'),
+                ],
+                'resolve' => function (MuxAsset $item, array $args) {
+                    return Mux::getThumbnailUrl($item->playbackId($this->getPolicy($args)), params: $args['params'] ?? []);
+                },
+            ],
+            'gif' => [
+                'type' => GraphQL::string(),
+                'description' => 'Url of an animated gif image representing the video',
+                'args' => [
+                    ...$this->playbackPolicyArgs(),
+                    ...$this->paramArgs('gif url'),
+                ],
+                'resolve' => function (MuxAsset $item, array $args) {
+                    return Mux::getGifUrl($item->playbackId($this->getPolicy($args)), params: $args['params'] ?? []);
+                },
+            ],
+            'placeholder' => [
+                'type' => GraphQL::string(),
+                'description' => 'Data uri of a blurry image placeholder',
+                'args' => [
+                    ...$this->playbackPolicyArgs(),
+                    ...$this->paramArgs('placeholder url'),
+                ],
+                'resolve' => function (MuxAsset $item, array $args) {
+                    return Mux::getPlaceholderDataUri($item->playbackId($this->getPolicy($args)), params: $args['params'] ?? []);
+                },
+            ],
+            'playback_modifiers' => [
+                'type' => GraphQL::type(JsonArgument::NAME),
+                'description' => 'Playback modifiers included in playback urls by default',
+                'resolve' => fn () => Arr::wrap(config('mux.playback_modifiers', [])),
+            ],
+        ];
+    }
+
+    protected function getPolicy(array $args): ?MuxPlaybackPolicy
+    {
+        Validator::make($args, ['policy' => ['string', 'nullable', 'in:public,signed']])->validate();
+        return MuxPlaybackPolicy::make($args['policy'] ?? null);
+    }
+}

--- a/src/GraphQL/MuxPlaybackIdType.php
+++ b/src/GraphQL/MuxPlaybackIdType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Daun\StatamicMux\GraphQL;
+
+use Daun\StatamicMux\Data\MuxPlaybackId;
+use Statamic\Facades\GraphQL;
+
+class MuxPlaybackIdType extends \Rebing\GraphQL\Support\Type
+{
+    const NAME = 'MuxPlaybackId';
+
+    protected $attributes = [
+        'name' => self::NAME,
+        'description' => 'Playback id allowing streaming access to a Mux video',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => GraphQL::string(),
+                'resolve' => fn (MuxPlaybackId $item) => $item->id(),
+            ],
+            'policy' => [
+                'type' => GraphQL::string(),
+                'resolve' => fn (MuxPlaybackId $item) => $item->policy(),
+            ],
+        ];
+    }
+}

--- a/src/Mux/MuxService.php
+++ b/src/Mux/MuxService.php
@@ -170,60 +170,44 @@ class MuxService
         return null;
     }
 
-    public function getPlaybackUrl(Asset $asset, ?MuxPlaybackPolicy $policy = null, array $params = []): ?string
+    public function getPlaybackUrl(MuxPlaybackId $playbackId, array $params = []): ?string
     {
-        if ($playbackId = $this->getPlaybackId($asset, $policy)) {
-            $params = $params + $this->getDefaultPlaybackModifiers();
+        $params = $params + $this->getDefaultPlaybackModifiers();
 
-            return $this->signUrl($this->urls->playback($playbackId->id()), $playbackId, MuxAudience::Video, $params);
-        } else {
-            return null;
-        }
+        return $this->signUrl($this->urls->playback($playbackId->id()), $playbackId, MuxAudience::Video, $params);
     }
 
-    public function getPlaybackToken(Asset $asset, ?MuxPlaybackPolicy $policy = null, array $params = []): ?string
+    public function getPlaybackToken(MuxPlaybackId $playbackId, array $params = []): ?string
     {
-        if ($playbackId = $this->getPlaybackId($asset, $policy)) {
-            $params = $params + $this->getDefaultPlaybackModifiers();
+        $params = $params + $this->getDefaultPlaybackModifiers();
 
-            return $playbackId->isSigned()
-                ? $this->urls->token($playbackId->id(), MuxAudience::Video, $params)
-                : null;
-        } else {
-            return null;
-        }
+        return $playbackId->isSigned()
+            ? $this->urls->token($playbackId->id(), MuxAudience::Video, $params)
+            : null;
     }
 
-    public function getThumbnailUrl(Asset $asset, ?MuxPlaybackPolicy $policy = null, array $params = []): ?string
+    public function getThumbnailUrl(MuxPlaybackId $playbackId, array $params = []): ?string
     {
-        if ($playbackId = $this->getPlaybackId($asset, $policy)) {
-            $format = $params['format'] ?? 'jpg';
-            $params = Arr::except($params, 'format');
+        $format = $params['format'] ?? 'jpg';
+        $params = Arr::except($params, 'format');
 
-            return $this->signUrl($this->urls->thumbnail($playbackId->id(), $format), $playbackId, MuxAudience::Thumbnail, $params);
-        } else {
-            return null;
-        }
+        return $this->signUrl($this->urls->thumbnail($playbackId->id(), $format), $playbackId, MuxAudience::Thumbnail, $params);
     }
 
-    public function getGifUrl(Asset $asset, ?MuxPlaybackPolicy $policy = null, array $params = []): ?string
+    public function getGifUrl(MuxPlaybackId $playbackId, array $params = []): ?string
     {
-        if ($playbackId = $this->getPlaybackId($asset, $policy)) {
-            $format = $params['format'] ?? 'gif';
-            $params = Arr::except($params, 'format');
+        $format = $params['format'] ?? 'gif';
+        $params = Arr::except($params, 'format');
 
-            return $this->signUrl($this->urls->animated($playbackId->id(), $format), $playbackId, MuxAudience::Gif, $params);
-        } else {
-            return null;
-        }
+        return $this->signUrl($this->urls->animated($playbackId->id(), $format), $playbackId, MuxAudience::Gif, $params);
     }
 
-    public function getPlaceholderDataUri(Asset $asset, ?MuxPlaybackPolicy $policy = null, array $params = []): string
+    public function getPlaceholderDataUri(MuxPlaybackId $playbackId, array $params = []):?string
     {
         $fallback = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-        $thumbnail = $this->getThumbnailUrl($asset, $policy, ['width' => 100] + $params);
+        $thumbnail = $this->getThumbnailUrl($playbackId, ['width' => 100] + $params);
         if ($thumbnail) {
-            $key = sprintf('%s-%s', $this->getMuxId($asset), md5(json_encode($params)));
+            $key = sprintf('%s-%s', $playbackId->id(), md5(json_encode($params)));
 
             return $this->placeholders->forUrl($thumbnail, $key);
         } else {

--- a/src/Tags/Concerns/GetsAssetFromContext.php
+++ b/src/Tags/Concerns/GetsAssetFromContext.php
@@ -2,6 +2,7 @@
 
 namespace Daun\StatamicMux\Tags\Concerns;
 
+use Illuminate\Support\Arr;
 use Statamic\Assets\Asset;
 use Statamic\Facades\Asset as Assets;
 use Statamic\Fields\Value;
@@ -9,6 +10,11 @@ use Statamic\Fields\Value;
 trait GetsAssetFromContext
 {
     protected $assetParams = ['src', 'path', 'url', 'asset'];
+
+    protected function getNonAssetParams(): array
+    {
+        return Arr::except($this->params->all(), $this->assetParams);
+    }
 
     /**
      * Get the asset model from a path or id in the context.

--- a/src/Tags/Concerns/ReadsMuxData.php
+++ b/src/Tags/Concerns/ReadsMuxData.php
@@ -2,6 +2,7 @@
 
 namespace Daun\StatamicMux\Tags\Concerns;
 
+use Daun\StatamicMux\Data\MuxPlaybackId;
 use Daun\StatamicMux\Facades\Mux;
 use Daun\StatamicMux\Mux\Enums\MuxPlaybackPolicy;
 
@@ -29,31 +30,29 @@ trait ReadsMuxData
      */
     protected function getMuxId($asset = null): ?string
     {
-        $asset = $this->getAssetFromContext($asset);
-
-        return $asset ? Mux::getMuxId($asset) : null;
+        return ($asset = $this->getAssetFromContext($asset))
+            ? Mux::getMuxId($asset)
+            : null;
     }
 
     /**
-     * Get the playback id of a video
+     * Get the playback id instance of a video
      */
-    protected function getPlaybackId($asset = null): ?string
+    protected function getPlaybackId($asset = null): ?MuxPlaybackId
     {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getPlaybackId($asset, policy: $policy)?->id() : null;
+        return ($asset = $this->getAssetFromContext($asset))
+            ? Mux::getPlaybackId($asset, policy: $this->guessRequestedPolicy())
+            : null;
     }
 
     /**
      * Get the playback url of a video
      */
-    protected function getPlaybackUrl($asset = null): ?string
+    protected function getPlaybackUrl($asset = null, ?array $params = []): ?string
     {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getPlaybackUrl($asset, policy: $policy) : null;
+        return ($playbackId = $this->getPlaybackId($asset))
+            ? Mux::getPlaybackUrl($playbackId, params: $params)
+            : null;
     }
 
     /**
@@ -61,10 +60,9 @@ trait ReadsMuxData
      */
     protected function getPlaybackToken($asset = null, ?array $params = []): ?string
     {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getPlaybackToken($asset, policy: $policy, params: $params) : null;
+        return ($playbackId = $this->getPlaybackId($asset))
+            ? Mux::getPlaybackToken($playbackId, params: $params)
+            : null;
     }
 
     /**
@@ -72,10 +70,9 @@ trait ReadsMuxData
      */
     protected function getThumbnailUrl($asset = null, ?array $params = []): ?string
     {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getThumbnailUrl($asset, policy: $policy, params: $params) : null;
+        return ($playbackId = $this->getPlaybackId($asset))
+            ? Mux::getThumbnailUrl($playbackId, params: $params)
+            : null;
     }
 
     /**
@@ -83,10 +80,9 @@ trait ReadsMuxData
      */
     protected function getGifUrl($asset = null, ?array $params = []): ?string
     {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getGifUrl($asset, policy: $policy, params: $params) : null;
+        return ($playbackId = $this->getPlaybackId($asset))
+            ? Mux::getGifUrl($playbackId, params: $params)
+            : null;
     }
 
     /**
@@ -94,32 +90,9 @@ trait ReadsMuxData
      */
     protected function getPlaceholderDataUri($asset = null, ?array $params = []): ?string
     {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getPlaceholderDataUri($asset, policy: $policy, params: $params) : null;
-    }
-
-    /**
-     * Whether this video requires signed playback urls
-     */
-    protected function isSigned($asset = null): bool
-    {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getPlaybackId($asset, policy: $policy)?->isSigned() : false;
-    }
-
-    /**
-     * Whether this video generates public playback urls
-     */
-    protected function isPublic($asset = null): bool
-    {
-        $asset = $this->getAssetFromContext($asset);
-        $policy = $this->guessRequestedPolicy();
-
-        return $asset ? Mux::getPlaybackId($asset, policy: $policy)?->isPublic() : false;
+        return ($playbackId = $this->getPlaybackId($asset))
+            ? Mux::getPlaceholderDataUri($playbackId, params: $params)
+            : null;
     }
 
     /**

--- a/src/Tags/MuxTags.php
+++ b/src/Tags/MuxTags.php
@@ -65,21 +65,20 @@ class MuxTags extends Tags
         try {
             $muxId = $this->getMuxId($asset);
             $playbackId = $this->getPlaybackId($asset);
-            $playbackModifiers = $this->getDefaultPlaybackModifiers();
-            $playbackToken = $this->getPlaybackToken($asset, $playbackModifiers);
-            $playbackIdSigned = $playbackToken ? "{$playbackId}?token={$playbackToken}" : $playbackId;
 
             $data = [
                 'mux_id' => $muxId,
-                'playback_id' => $playbackId,
-                'playback_id_signed' => $playbackIdSigned,
-                'playback_token' => $playbackToken,
+                'playback_id' => $playbackId?->id(),
+                'playback_policy' => $playbackId?->policy(),
+                'playback_modifiers' => ($playbackModifiers = $this->getDefaultPlaybackModifiers()),
+                'playback_token' => ($playbackToken = $this->getPlaybackToken($asset, $playbackModifiers)),
+                'playback_id_signed' => $playbackToken ? "{$playbackId->id()}?token={$playbackToken}" : $playbackId?->id(),
                 'playback_url' => $this->getPlaybackUrl($asset),
                 'thumbnail' => $this->getThumbnailUrl($asset),
                 'placeholder' => $this->getPlaceholderDataUri($asset),
                 'gif' => $this->getGifUrl($asset),
-                'is_public' => $this->isPublic($asset),
-                'is_signed' => $this->isSigned($asset),
+                'is_public' => $playbackId?->isPublic(),
+                'is_signed' => $playbackId?->isSigned(),
             ];
 
             return array_merge($asset->toAugmentedArray(), $data);
@@ -98,7 +97,7 @@ class MuxTags extends Tags
     public function video(): ?string
     {
         $asset = $this->getAssetFromContext();
-        $playbackId = $this->getPlaybackId($asset);
+        $playbackId = $this->getPlaybackId($asset)?->id();
         if (! $playbackId) {
             return null;
         }
@@ -145,7 +144,7 @@ class MuxTags extends Tags
     public function player(): ?string
     {
         $asset = $this->getAssetFromContext();
-        $playbackId = $this->getPlaybackId($asset);
+        $playbackId = $this->getPlaybackId($asset)?->id();
         if (! $playbackId) {
             return null;
         }
@@ -193,7 +192,7 @@ class MuxTags extends Tags
      */
     public function playbackId(): ?string
     {
-        return $this->getPlaybackId();
+        return $this->getPlaybackId()?->id();
     }
 
     /**
@@ -213,9 +212,7 @@ class MuxTags extends Tags
      */
     public function thumbnail(): ?string
     {
-        $params = collect($this->params->all())->except($this->assetParams)->all();
-
-        return $this->getThumbnailUrl(null, $params);
+        return $this->getThumbnailUrl(params: $this->getNonAssetParams());
     }
 
     /**
@@ -225,9 +222,7 @@ class MuxTags extends Tags
      */
     public function gif(): ?string
     {
-        $params = collect($this->params->all())->except($this->assetParams)->all();
-
-        return $this->getGifUrl(null, $params);
+        return $this->getGifUrl(params: $this->getNonAssetParams());
     }
 
     /**
@@ -237,9 +232,7 @@ class MuxTags extends Tags
      */
     public function placeholder(): ?string
     {
-        $params = collect($this->params->all())->except($this->assetParams)->all();
-
-        return $this->getPlaceholderDataUri(null, $params);
+        return $this->getPlaceholderDataUri(params: $this->getNonAssetParams());
     }
 
     /**


### PR DESCRIPTION
- Query Mux data from `mux_mirror` fields on asset blueprints
- Document available subfields
- Add query and usage example

Closes #2 