### PR TITLE
Render mux components from views

### DIFF
--- a/docs/tags/mux-player.md
+++ b/docs/tags/mux-player.md
@@ -50,3 +50,13 @@ Learn more about [customizing the look and feel of Mux Player](https://docs.mux.
   start-time="10"
 ></mux-player>
 ```
+
+## Customizing the view
+
+If you need to adjust the rendered html beyond what's possible with the standard parameters, you can
+publish the addon's views and make them your own. To do that, run the following command in your
+console. You'll then find the views in `resources/views/vendor/statamic-mux/`.
+
+```sh
+php artisan vendor:publish --tag=statamic-mux-views
+```

--- a/docs/tags/mux-video.md
+++ b/docs/tags/mux-video.md
@@ -56,13 +56,22 @@ to allow using the video as a background element:
 Any other attributes will be passed along to the the web component itself:
 
 ```antlers
-{{ mux:video src="assets::video.mp4" autoplay loop muted class="mt-3" }}
+{{ mux:video src="assets::video.mp4" class="mt-3" }}
 ```
 
 ```html
 <mux-video
   playback-id="85g23gYz7NmQu02YsY81ihuod6cZMxCp017ZrfglyLCKc"
-  autoplay loop muted
   class="mt-3"
 ></mux-video>
+```
+
+## Customizing the view
+
+If you need to adjust the rendered html beyond what's possible with the standard parameters, you can
+publish the addon's views and make them your own. To do that, run the following command in your
+console. You'll then find the views in `resources/views/vendor/statamic-mux/`.
+
+```sh
+php artisan vendor:publish --tag=statamic-mux-views
 ```

--- a/resources/views/mux-player.antlers.html
+++ b/resources/views/mux-player.antlers.html
@@ -1,0 +1,20 @@
+<mux-player
+  playback-id="{{ playback_id }}"
+  {{ if is_signed }}
+    playback-token="{{ playback_token }}"
+  {{ else }}
+    {{ foreach:playback_attributes as="modifier|value" }}
+      {{ modifier }}="{{ value }}"
+    {{ /foreach:playback_attributes }}
+  {{ /if }}
+  preload="metadata"
+  width="{{ width }}"
+  height="{{ height }}"
+  {{ autoplay | attribute:autoplay }}
+  {{ loop | attribute:loop }}
+  {{ muted | attribute:muted }}
+></mux-player>
+
+{{ if script }}
+  <script async src="https://unpkg.com/@mux/mux-player@3"></script>
+{{ /if }}

--- a/resources/views/mux-player.antlers.html
+++ b/resources/views/mux-player.antlers.html
@@ -3,16 +3,20 @@
   {{ if is_signed }}
     playback-token="{{ playback_token }}"
   {{ else }}
-    {{ foreach:playback_attributes as="modifier|value" }}
-      {{ modifier }}="{{ value }}"
+    {{ foreach:playback_attributes as="attr|value" }}
+      {{ attr }}="{{ value }}"
     {{ /foreach:playback_attributes }}
   {{ /if }}
+  poster="{{ poster }}"
   preload="metadata"
   width="{{ width }}"
   height="{{ height }}"
   {{ autoplay | attribute:autoplay }}
   {{ loop | attribute:loop }}
   {{ muted | attribute:muted }}
+  {{ foreach:attributes as="attr|value" }}
+    {{ attr }}="{{ value }}"
+  {{ /foreach:attributes }}
 ></mux-player>
 
 {{ if script }}

--- a/resources/views/mux-video.antlers.html
+++ b/resources/views/mux-video.antlers.html
@@ -1,0 +1,26 @@
+<mux-video
+  {{ if is_signed }}
+    playback-id="{{ playback_id_signed }}"
+  {{ else }}
+    playback-id="{{ playback_id }}"
+    {{ foreach:playback_attributes as="modifier|value" }}
+      {{ modifier }}="{{ value }}"
+    {{ /foreach:playback_attributes }}
+  {{ /if }}
+  poster="{{ poster }}"
+  preload="metadata"
+  width="{{ width }}"
+  height="{{ height }}"
+  playsinline
+  {{ if background }}
+    autoplay loop muted
+  {{ else }}
+    {{ autoplay | attribute:autoplay }}
+    {{ loop | attribute:loop }}
+    {{ muted | attribute:muted }}
+  {{ /if }}
+></mux-video>
+
+{{ if script }}
+  <script async src="https://unpkg.com/@mux/mux-video@0"></script>
+{{ /if }}

--- a/resources/views/mux-video.antlers.html
+++ b/resources/views/mux-video.antlers.html
@@ -3,8 +3,8 @@
     playback-id="{{ playback_id_signed }}"
   {{ else }}
     playback-id="{{ playback_id }}"
-    {{ foreach:playback_attributes as="modifier|value" }}
-      {{ modifier }}="{{ value }}"
+    {{ foreach:playback_attributes as="attr|value" }}
+      {{ attr }}="{{ value }}"
     {{ /foreach:playback_attributes }}
   {{ /if }}
   poster="{{ poster }}"
@@ -19,6 +19,9 @@
     {{ loop | attribute:loop }}
     {{ muted | attribute:muted }}
   {{ /if }}
+  {{ foreach:attributes as="attr|value" }}
+    {{ attr }}="{{ value }}"
+  {{ /foreach:attributes }}
 ></mux-video>
 
 {{ if script }}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -52,6 +52,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         $this->bootPermissions();
         $this->autoPublishConfig();
+        $this->publishViews();
     }
 
     protected function registerMuxApi()
@@ -142,6 +143,17 @@ class ServiceProvider extends AddonServiceProvider
         ], "{$filename}-config");
 
         return parent::bootConfig();
+    }
+
+    protected function publishViews(): self
+    {
+        $addon = $this->getAddon()->slug();
+
+        $this->publishes([
+            __DIR__.'/../resources/views' => resource_path('views/vendor/statamic-mux')
+        ], "{$addon}-views");
+
+        return $this;
     }
 
     protected function autoPublishConfig(): self


### PR DESCRIPTION
- Use Antlers views to render `mux-video` and `mux-player` components
- Allow publishing and customizing the views
- Improve testability