### PR TITLE
Autocreate playback id on GraphQL requests

### DIFF
--- a/src/GraphQL/MuxMirrorType.php
+++ b/src/GraphQL/MuxMirrorType.php
@@ -123,6 +123,7 @@ class MuxMirrorType extends \Rebing\GraphQL\Support\Type
             ],
         ];
     }
+
     protected function withPlaybackId(MuxAsset $asset, array $args, Closure $callback): mixed
     {
         if ($playbackId = Mux::getPlaybackId($asset->asset, $this->getPolicy($args))) {


### PR DESCRIPTION
- Playback ids aren't automatically generated on GraphQL requests
- They are generated when accessing Mux data via the Antlers tag
- This makes both types of access behave identically
- Closes #19 