### PR TITLE
Render `iframe` embeds

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -43,6 +43,7 @@ export default defineConfig({
               { text: 'mux', link: '/tags/mux' },
               { text: 'mux:video', link: '/tags/mux-video' },
               { text: 'mux:player', link: '/tags/mux-player' },
+              { text: 'mux:embed', link: '/tags/mux-embed' },
               { text: 'mux:thumbnail', link: '/tags/mux-thumbnail' },
               { text: 'mux:placeholder', link: '/tags/mux-placeholder' },
               { text: 'mux:gif', link: '/tags/mux-gif' },

--- a/docs/tags/mux-embed.md
+++ b/docs/tags/mux-embed.md
@@ -1,0 +1,43 @@
+# `mux:embed` <Badge type="info">Antlers Tag</Badge>
+
+Render an iframe to embed a Mux Player. While the official web components provide a better viewer
+experience, they require component scripts. This tag offers a simple script-free alternative for
+embedding videos. See the [Mux Player docs](https://www.mux.com/docs/guides/mux-player-web#html-embed)
+for customization options.
+
+```antlers
+{{ mux:embed src="assets::video.mp4" }}
+```
+
+::: code-group
+
+```html [Output]
+<iframe
+  src="https://player.mux.com/85g23gYz7NmQu02YsY81ihuod6cZMxCp017ZrfglyLCKc"
+  width="1920"
+  height="1080"
+></iframe>
+```
+
+:::
+
+## Custom attributes
+
+Any other attributes will be passed along as query params to allow for customization. Learn more
+about [customizing the look and feel of Mux Player](https://docs.mux.com/guides/player-customize-look-and-feel).
+
+```antlers
+{{ mux:embed src="assets::video.mp4" primary-color="#075389" start-time="10" }}
+```
+
+```html
+<iframe
+  src="https://player.mux.com/85g23gYz7NmQu02YsY81ihuod6cZMxCp017ZrfglyLCKc?primary_color=%23075389&start_time=10"
+  width="1920"
+  height="1080"
+></iframe>
+```
+
+## Customizing the view
+
+<!--@include: ../partials/vendor-views.md-->

--- a/resources/views/mux-embed.antlers.html
+++ b/resources/views/mux-embed.antlers.html
@@ -1,0 +1,23 @@
+{{ url = 'https://player.mux.com/' + playback_id }}
+
+{{ modifiers = arr(
+  "autoplay" => background || autoplay,
+  "loop" => background || loop,
+  "muted" => background || muted,
+)}}
+
+{{ params = playback_attributes | merge(modifiers) | merge(attributes) }}
+
+{{ if params | length > 0 }}
+  {{ query = params | to_qs }}
+  {{ url = url + '?' + query }}
+{{ /if }}
+
+<iframe
+  src="{{ url }}"
+  width="{{ width }}"
+  height="{{ height }}"
+  {{ foreach:attributes as="attr|value" }}
+    {{ attr }}="{{ value }}"
+  {{ /foreach:attributes }}
+></iframe>

--- a/src/Tags/MuxTags.php
+++ b/src/Tags/MuxTags.php
@@ -110,6 +110,16 @@ class MuxTags extends Tags
     }
 
     /**
+     * Tag {{ mux:embed }}
+     *
+     * Return a rendered <iframe> html embed.
+     */
+    public function embed(): ?string
+    {
+        return $this->component('mux-embed');
+    }
+
+    /**
      * Render a custom-element view.
      */
     protected function component(string $view): ?string


### PR DESCRIPTION
- Add new `mux:embed` tag to render an `iframe`
- Closes #23

## Example

```antlers
{{ mux:embed src="assets::video.mp4" }}
```

## Result

```html
<iframe
  src="https://player.mux.com/85g23gYz7NmQu02YsY81ihuod6cZMxCp017ZrfglyLCKc"
  width="1920"
  height="1080"
></iframe>
```