### PR TITLE
Upgrade to Mux SDK v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "firebase/php-jwt": "^6.10",
         "guzzlehttp/guzzle": "^7.8",
         "laravel/framework": "^9.21 || ^10.0 || ^11.0 || ^12.0",
-        "muxinc/mux-php": "^4.0",
+        "muxinc/mux-php": "^5.0",
         "srwiez/thumbhash": "^1.2",
         "statamic/cms": "^4.0 || ^5.0"
     },


### PR DESCRIPTION
- Adds support for asset metadata