### PR TITLE
Update asset meta on save

### DIFF
--- a/config/mux.php
+++ b/config/mux.php
@@ -80,19 +80,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Playback Policy
-    |--------------------------------------------------------------------------
-    |
-    | The playback policy applied when creating new assets: 'public' or 'signed'
-    |
-    | Learn about policies at https://docs.mux.com/guides/secure-video-playback
-    |
-    */
-
-    'playback_policy' => env('MUX_PLAYBACK_POLICY', 'public'),
-
-    /*
-    |--------------------------------------------------------------------------
     | Video Quality
     |--------------------------------------------------------------------------
     |
@@ -107,6 +94,19 @@ return [
     */
 
     'video_quality' => env('MUX_VIDEO_QUALITY', 'plus'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Playback Policy
+    |--------------------------------------------------------------------------
+    |
+    | The playback policy applied when creating new assets: 'public' or 'signed'
+    |
+    | Learn about policies at https://docs.mux.com/guides/secure-video-playback
+    |
+    */
+
+    'playback_policy' => env('MUX_PLAYBACK_POLICY', 'public'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/mux.php
+++ b/config/mux.php
@@ -62,6 +62,8 @@ return [
 
         'enabled' => env('MUX_MIRROR_ENABLED', true),
 
+        'sync_meta' => true,
+
     ],
 
     /*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,32 @@ return [
 ];
 ```
 
+## Mirror Field Settings
+
+Configure the behavior of assets mirrored to Mux through the [Mirror fieldtype](/upload). The `enabled` flag
+turns mirroring on or off globally. The `sync_meta` flag controls whether
+[Mux metadata](https://www.mux.com/docs/guides/add-metadata-to-your-videos) is updated
+whenever the asset is updated in Statamic. Turn it off to only set the metadata once on creation.
+
+```php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Mirror Local Video Assets to Mux
+    |--------------------------------------------------------------------------
+    */
+
+    'mirror' => [
+
+        'enabled' => env('MUX_MIRROR_ENABLED', true), // [!code focus]
+
+        'sync_meta' => true, // [!code focus]
+
+    ],
+
+];
+```
+
 ## Test Mode
 
 Mux offers a test mode for evaluating their service without incurring charges for storage or streaming.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,24 +71,6 @@ return [
 ];
 ```
 
-## Playback Policy
-
-Videos uploaded to Mux can restrict access by requiring signed playback urls.
-Learn more about [Setting Up Secure Playback](/secure-playback).
-
-```php
-return [
-    /*
-    |--------------------------------------------------------------------------
-    | Playback Policy
-    |--------------------------------------------------------------------------
-    */
-
-    'playback_policy' => env('MUX_PLAYBACK_POLICY', 'public'), // [!code focus]
-
-];
-```
-
 ## Video Quality
 
 Mux offers three quality levels. Learn more at
@@ -115,6 +97,24 @@ You can set this to `null` to use the default quality setting of your Mux accoun
 defined one in the [Default Video Quality Settings](https://dashboard.mux.com/organizations/59g3uj/settings/video-quality)
 of your Mux account dashboard.
 
+## Playback Policy
+
+Videos uploaded to Mux can restrict access by requiring signed playback urls.
+Learn more about [Setting Up Secure Playback](/secure-playback).
+
+```php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Playback Policy
+    |--------------------------------------------------------------------------
+    */
+
+    'playback_policy' => env('MUX_PLAYBACK_POLICY', 'public'), // [!code focus]
+
+];
+```
+
 ## Playback Modifiers
 
 Change the default playback behavior of video streams received from Mux.
@@ -129,9 +129,12 @@ return [
     |--------------------------------------------------------------------------
     */
 
-    'playback_modifiers' => [ // [!code focus]
+    'playback_modifiers' => [
+
         'min_resolution' => '720p', // [!code focus]
+
         'max_resolution' => '1440p', // [!code focus]
+
     ],
 
 ];

--- a/src/Mux/Actions/UpdateMuxAsset.php
+++ b/src/Mux/Actions/UpdateMuxAsset.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Daun\StatamicMux\Mux\Actions;
+
+use Daun\StatamicMux\Concerns\GeneratesAssetData;
+use Daun\StatamicMux\Mux\MuxApi;
+use Daun\StatamicMux\Mux\MuxService;
+use Illuminate\Support\Facades\Log;
+use MuxPhp\Models\UpdateAssetRequest;
+use Statamic\Assets\Asset;
+
+class UpdateMuxAsset
+{
+    use GeneratesAssetData;
+
+    public function __construct(
+        protected MuxService $service,
+        protected MuxApi $api,
+    ) {}
+
+    /**
+     * Update an asset's existing Mux metadata.
+     */
+    public function handle(Asset $asset): bool
+    {
+        if (! $asset->isVideo()) {
+            return false;
+        }
+
+        if (! $this->service->hasExistingMuxAsset($asset)) {
+            return false;
+        }
+
+        try {
+            $this->updateMuxData($asset);
+        } catch (\Throwable $th) {
+            Log::error($th->getMessage());
+
+            throw new \Exception("Failed to update asset data on Mux: {$th->getMessage()}");
+        }
+
+        return true;
+    }
+
+    /**
+     * Update data on Mux for an existing asset.
+     */
+    protected function updateMuxData(Asset $asset): void
+    {
+        $muxId = $this->service->getMuxId($asset);
+
+        $request = new UpdateAssetRequest($this->getAssetData($asset));
+
+        $this->api->assets()->updateAsset($muxId, $request)->getData();
+    }
+}

--- a/src/Mux/MuxService.php
+++ b/src/Mux/MuxService.php
@@ -8,6 +8,7 @@ use Daun\StatamicMux\Data\MuxPlaybackId;
 use Daun\StatamicMux\Mux\Actions\CreateMuxAsset;
 use Daun\StatamicMux\Mux\Actions\DeleteMuxAsset;
 use Daun\StatamicMux\Mux\Actions\RequestPlaybackId;
+use Daun\StatamicMux\Mux\Actions\UpdateMuxAsset;
 use Daun\StatamicMux\Mux\Enums\MuxAudience;
 use Daun\StatamicMux\Mux\Enums\MuxPlaybackPolicy;
 use Daun\StatamicMux\Placeholders\PlaceholderService;
@@ -61,6 +62,22 @@ class MuxService
         }
 
         return $muxId ?? null;
+    }
+
+    /**
+     * Update data of a video asset on Mux.
+     */
+    public function updateMuxAsset(Asset|string $asset): bool
+    {
+        if (is_string($asset)) {
+            $asset = Assets::find($asset);
+        }
+
+        if ($asset) {
+            return $this->app->make(UpdateMuxAsset::class)->handle($asset);
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/Subscribers/MirrorFieldSubscriber.php
+++ b/src/Subscribers/MirrorFieldSubscriber.php
@@ -23,11 +23,10 @@ class MirrorFieldSubscriber implements ShouldQueue
     public function subscribe(Dispatcher $events): array
     {
         return [
-            // AssetSaved::class => 'createMuxAsset',
             AssetUploaded::class => 'createMuxAsset',
             AssetReuploaded::class => 'createMuxAsset',
-            AssetSaved::class => 'updateMuxAsset',
             AssetDeleted::class => 'deleteMuxAsset',
+            AssetSaved::class => 'updateMuxAsset',
         ];
     }
 
@@ -47,8 +46,10 @@ class MirrorFieldSubscriber implements ShouldQueue
      */
     public function updateMuxAsset(AssetSaved $event): void
     {
-        if (MirrorField::shouldMirror($event->asset)) {
-            $this->service->updateMuxAsset($event->asset);
+        if (MirrorField::shouldMirror($event->asset) && MirrorField::shouldUpdateMeta()) {
+            if ($this->service->getMuxId($event->asset)) {
+                $this->service->updateMuxAsset($event->asset);
+            }
         }
     }
 

--- a/src/Subscribers/MirrorFieldSubscriber.php
+++ b/src/Subscribers/MirrorFieldSubscriber.php
@@ -26,6 +26,7 @@ class MirrorFieldSubscriber implements ShouldQueue
             // AssetSaved::class => 'createMuxAsset',
             AssetUploaded::class => 'createMuxAsset',
             AssetReuploaded::class => 'createMuxAsset',
+            AssetSaved::class => 'updateMuxAsset',
             AssetDeleted::class => 'deleteMuxAsset',
         ];
     }
@@ -38,6 +39,16 @@ class MirrorFieldSubscriber implements ShouldQueue
         if (MirrorField::shouldMirror($event->asset)) {
             $force = $event instanceof AssetReuploaded;
             $this->service->createMuxAsset($event->asset, $force);
+        }
+    }
+
+    /**
+     * Update a mirrored asset on Mux.
+     */
+    public function updateMuxAsset(AssetSaved $event): void
+    {
+        if (MirrorField::shouldMirror($event->asset)) {
+            $this->service->updateMuxAsset($event->asset);
         }
     }
 

--- a/src/Subscribers/MirrorFieldSubscriber.php
+++ b/src/Subscribers/MirrorFieldSubscriber.php
@@ -11,7 +11,6 @@ use Statamic\Events\AssetDeleted;
 use Statamic\Events\AssetReuploaded;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
-use Statamic\Facades\CP\Toast;
 
 class MirrorFieldSubscriber implements ShouldQueue
 {
@@ -36,17 +35,9 @@ class MirrorFieldSubscriber implements ShouldQueue
      */
     public function createMuxAsset(AssetSaved|AssetUploaded|AssetReuploaded $event): void
     {
-        if (! MirrorField::shouldMirror($event->asset)) {
-            return;
-        }
-
-        $force = $event instanceof AssetReuploaded;
-
-        try {
+        if (MirrorField::shouldMirror($event->asset)) {
+            $force = $event instanceof AssetReuploaded;
             $this->service->createMuxAsset($event->asset, $force);
-            Toast::info(__('statamic-mux::messages.toast.uploaded', ['file' => $event->asset->basename()]));
-        } catch (\Throwable $th) {
-            Toast::error(__('statamic-mux::messages.toast.upload_failed', ['error' => $th->getMessage()]));
         }
     }
 
@@ -55,10 +46,8 @@ class MirrorFieldSubscriber implements ShouldQueue
      */
     public function deleteMuxAsset(AssetDeleted $event): void
     {
-        if (! MirrorField::shouldMirror($event->asset)) {
-            return;
+        if (MirrorField::shouldMirror($event->asset)) {
+            $this->service->deleteMuxAsset($event->asset);
         }
-
-        $this->service->deleteMuxAsset($event->asset);
     }
 }

--- a/src/Support/MirrorField.php
+++ b/src/Support/MirrorField.php
@@ -38,6 +38,11 @@ class MirrorField
         return static::configured() && static::enabled() && static::enabledForAsset($asset);
     }
 
+    public static function shouldUpdateMeta(): bool
+    {
+        return (bool) config('mux.mirror.sync_meta', true);
+    }
+
     public static function existsInBlueprint(Asset|AssetContainer $asset): bool
     {
         return (bool) static::getFromBlueprint($asset);


### PR DESCRIPTION
- Update Mux metadata whenever the underlying Statamic asset is saved
- No performance issues as long as a queue is configured
- Can be disabled using a new `mux.mirror.sync_meta` flag