### PR TITLE
Allow fetching all assets

### DIFF
--- a/src/Commands/PruneCommand.php
+++ b/src/Commands/PruneCommand.php
@@ -46,7 +46,7 @@ class PruneCommand extends Command
             $this->newLine();
         }
 
-        $muxAssets = $service->listMuxAssets();
+        $muxAssets = $service->listMuxAssets(all: true);
         $actualMuxIds = $muxAssets->pluck('id');
 
         if ($actualMuxIds->isEmpty()) {

--- a/src/Mux/MuxService.php
+++ b/src/Mux/MuxService.php
@@ -136,23 +136,23 @@ class MuxService
     /**
      * List existing Mux assets
      */
-    public function listMuxAssets(int $limit = 100, int $page = 1)
+    public function listMuxAssets(int $limit = 100, int $page = 1, bool $all = false)
     {
-        // Below max page size, just pass on the request
-        if ($limit <= 100) {
-            return collect($this->api->assets()->listAssets($limit, $page)->getData());
+        // Paginate to fetch all assets
+        if ($all) {
+            $assets = collect();
+            $new = null;
+
+            do {
+                $new = $this->api->assets()->listAssets(100, $page)->getData();
+                $assets->push(...$new);
+                $page++;
+            } while ($new !== [] && ($limit <= 0 || $assets->count() < $limit));
+
+            return $assets;
         }
 
-        // Above max page size, we need to paginate
-        $assets = collect();
-        $new = null;
-        do {
-            $new = $this->api->assets()->listAssets(100, $page)->getData();
-            $assets->push(...$new);
-            $page++;
-        } while ($new !== [] && $assets->count() < $limit);
-
-        return $assets->slice(0, $limit)->values();
+        return collect($this->api->assets()->listAssets($limit, $page)->getData());
     }
 
     public function getMuxId(Asset $asset): ?string

--- a/tests/Feature/MuxApiTest.php
+++ b/tests/Feature/MuxApiTest.php
@@ -99,5 +99,6 @@ test('sends API request to create asset', function () {
 
     $this->guzzler->assertHistoryCount(1);
 
+    expect($muxAsset)->toBeInstanceOf(\MuxPhp\Models\Asset::class);
     expect($muxAsset->getId())->toBe('SqQnqz6s5MBuXGvJaUWdXuXM93J9Q2yv');
 });

--- a/tests/Feature/MuxServiceTest.php
+++ b/tests/Feature/MuxServiceTest.php
@@ -2,11 +2,16 @@
 
 use Daun\StatamicMux\Mux\Enums\MuxPlaybackPolicy;
 use Daun\StatamicMux\Mux\MuxApi;
+use Daun\StatamicMux\Mux\MuxClient;
 use Daun\StatamicMux\Mux\MuxService;
 use Daun\StatamicMux\Support\MirrorField;
 use Statamic\Facades\Stache;
 
 beforeEach(function () {
+    $this->app->bind(MuxClient::class, fn () => $this->guzzler->getClient());
+    $this->api = $this->app->make(MuxApi::class);
+    $this->app->bind(MuxApi::class, fn () => $this->api);
+
     $this->service = $this->app->make(MuxService::class);
 
     $this->addMirrorFieldToAssetBlueprint();
@@ -61,4 +66,219 @@ test('returns the default playback modifiers', function () {
 
     config(['mux.playback_modifiers' => ['width' => 100, 'height' => 100]]);
     expect($this->service->getDefaultPlaybackModifiers())->toEqual(['width' => 100, 'height' => 100]);
+});
+
+test('sends API request to list assets', function () {
+    $this->guzzler->expects($this->once())
+        ->ray()
+        ->get('https://api.mux.com/video/v1/assets')
+        ->withQuery([
+            'limit' => 100,
+            'page' => 1,
+        ])
+        ->willRespondJson([
+            'next_cursor' => 'tF601CUtCLmnYuHW01Vwl6BWcWTNv001uoaiK4C01jqk1acX802plAjZhTQ',
+            'data' => [
+                [
+                    'tracks' => [
+                        [
+                            'type' => 'video',
+                            'max_width' => 1920,
+                            'max_height' => 800,
+                            'max_frame_rate' => 24,
+                            'id' => 'HK01Bq7FrEQmIu3QpRiZZ98HQOOZjm6BYyg17eEunlyo',
+                            'duration' => 734.166667
+                        ],
+                        [
+                            'type' => 'audio',
+                            'max_channels' => 2,
+                            'id' => 'nNKHJqw2G9cE019AoK16CJr3O27gGnbtW4w525hJWqWw',
+                            'duration' => 734.143991
+                        ]
+                    ],
+                    'status' => 'ready',
+                    'playback_ids' => [
+                        [
+                            'policy' => 'public',
+                            'id' => '85g23gYz7NmQu02YsY81ihuod6cZMxCp017ZrfglyLCKc'
+                        ]
+                    ],
+                    'max_stored_resolution' => 'HD',
+                    'resolution_tier' => '1080p',
+                    'max_stored_frame_rate' => 24,
+                    'master_access' => 'none',
+                    'id' => '8jd7M77xQgf2NzuocJRPYdSdEfY5dLlcRwFARtgQqU4',
+                    'encoding_tier' => 'baseline',
+                    'video_quality' => 'basic',
+                    'duration' => 734.25,
+                    'created_at' => '1609869152',
+                    'aspect_ratio' => '12:5'
+                ],
+                [
+                    'tracks' => [
+                        [
+                            'type' => 'video',
+                            'max_width' => 1920,
+                            'max_height' => 1080,
+                            'max_frame_rate' => 29.97,
+                            'id' => 'RiyQPM31a1SPtfI802bEP2zD02F5FQVNL801FRHeE5t01G4',
+                            'duration' => 23.8238
+                        ],
+                        [
+                            'type' => 'audio',
+                            'max_channels' => 2,
+                            'id' => 'LvINTciHVoC017knMCH01y9pSi5OrDLCRaBPNDAoNJcmg',
+                            'duration' => 23.823792
+                        ]
+                    ],
+                    'status' => 'ready',
+                    'playback_ids' => [
+                        [
+                            'policy' => 'public',
+                            'id' => 'vAFLI2eKFFicXX00iHBS2vqt5JjJGg5HV6fQ4Xijgt1I'
+                        ]
+                    ],
+                    'max_stored_resolution' => 'HD',
+                    'resolution_tier' => '1080p',
+                    'max_stored_frame_rate' => 29.97,
+                    'master_access' => 'none',
+                    'id' => 'lJ4bGGsp7ZlPf02nMg015W02iHQLN9XnuuLRBsPS00xqd68',
+                    'encoding_tier' => 'smart',
+                    'video_quality' => 'plus',
+                    'duration' => 23.857167,
+                    'created_at' => '1609868768',
+                    'aspect_ratio' => '16:9'
+                ]
+            ]
+        ]);
+
+    $muxAssets = $this->service->listMuxAssets();
+
+    $this->guzzler->assertHistoryCount(1);
+
+    expect($muxAssets)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+    expect($muxAssets)->toHaveLength(2);
+    expect($muxAssets[0])->toBeInstanceOf(\MuxPhp\Models\Asset::class);
+    expect($muxAssets[0]->getId())->toBe('8jd7M77xQgf2NzuocJRPYdSdEfY5dLlcRwFARtgQqU4');
+    expect($muxAssets[1])->toBeInstanceOf(\MuxPhp\Models\Asset::class);
+    expect($muxAssets[1]->getId())->toBe('lJ4bGGsp7ZlPf02nMg015W02iHQLN9XnuuLRBsPS00xqd68');
+});
+
+test('paginates API request to list assets', function () {
+    $this->guzzler->expects($this->once())
+        ->ray()
+        ->get('https://api.mux.com/video/v1/assets')
+        ->withQuery([
+            'limit' => 100,
+            'page' => 1,
+        ])
+        ->willRespondJson([
+            'next_cursor' => 'tF601CUtCLmnYuHW01Vwl6BWcWTNv001uoaiK4C01jqk1acX802plAjZhTQ',
+            'data' => [
+                [
+                    'tracks' => [
+                        [
+                            'type' => 'video',
+                            'max_width' => 1920,
+                            'max_height' => 800,
+                            'max_frame_rate' => 24,
+                            'id' => 'HK01Bq7FrEQmIu3QpRiZZ98HQOOZjm6BYyg17eEunlyo',
+                            'duration' => 734.166667
+                        ],
+                        [
+                            'type' => 'audio',
+                            'max_channels' => 2,
+                            'id' => 'nNKHJqw2G9cE019AoK16CJr3O27gGnbtW4w525hJWqWw',
+                            'duration' => 734.143991
+                        ]
+                    ],
+                    'status' => 'ready',
+                    'playback_ids' => [
+                        [
+                            'policy' => 'public',
+                            'id' => '85g23gYz7NmQu02YsY81ihuod6cZMxCp017ZrfglyLCKc'
+                        ]
+                    ],
+                    'max_stored_resolution' => 'HD',
+                    'resolution_tier' => '1080p',
+                    'max_stored_frame_rate' => 24,
+                    'master_access' => 'none',
+                    'id' => '8jd7M77xQgf2NzuocJRPYdSdEfY5dLlcRwFARtgQqU4',
+                    'encoding_tier' => 'baseline',
+                    'video_quality' => 'basic',
+                    'duration' => 734.25,
+                    'created_at' => '1609869152',
+                    'aspect_ratio' => '12:5'
+                ]
+            ]
+        ]);
+
+    $this->guzzler->expects($this->once())
+        ->ray()
+        ->get('https://api.mux.com/video/v1/assets')
+        ->withQuery([
+            'limit' => 100,
+            'page' => 2,
+        ])
+        ->willRespondJson([
+            'next_cursor' => 'tF601CUtCLmnYuHW01Vwl6BWcWTNv001uoaiK4C01jqk1acX802plAjZhTQ',
+            'data' => [
+                [
+                    'tracks' => [
+                        [
+                            'type' => 'video',
+                            'max_width' => 1920,
+                            'max_height' => 1080,
+                            'max_frame_rate' => 29.97,
+                            'id' => 'RiyQPM31a1SPtfI802bEP2zD02F5FQVNL801FRHeE5t01G4',
+                            'duration' => 23.8238
+                        ],
+                        [
+                            'type' => 'audio',
+                            'max_channels' => 2,
+                            'id' => 'LvINTciHVoC017knMCH01y9pSi5OrDLCRaBPNDAoNJcmg',
+                            'duration' => 23.823792
+                        ]
+                    ],
+                    'status' => 'ready',
+                    'playback_ids' => [
+                        [
+                            'policy' => 'public',
+                            'id' => 'vAFLI2eKFFicXX00iHBS2vqt5JjJGg5HV6fQ4Xijgt1I'
+                        ]
+                    ],
+                    'max_stored_resolution' => 'HD',
+                    'resolution_tier' => '1080p',
+                    'max_stored_frame_rate' => 29.97,
+                    'master_access' => 'none',
+                    'id' => 'lJ4bGGsp7ZlPf02nMg015W02iHQLN9XnuuLRBsPS00xqd68',
+                    'encoding_tier' => 'smart',
+                    'video_quality' => 'plus',
+                    'duration' => 23.857167,
+                    'created_at' => '1609868768',
+                    'aspect_ratio' => '16:9'
+                ]
+            ]
+        ]);
+
+    $this->guzzler->expects($this->once())
+        ->ray()
+        ->get('https://api.mux.com/video/v1/assets')
+        ->withQuery([
+            'limit' => 100,
+            'page' => 3,
+        ])
+        ->willRespondJson([
+            'next_cursor' => null,
+            'data' => []
+        ]);
+
+    $muxAssets = $this->service->listMuxAssets(200);
+
+    $this->guzzler->assertHistoryCount(3);
+
+    expect($muxAssets)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+    expect($muxAssets)->toHaveLength(2);
+    expect($muxAssets[0])->toBeInstanceOf(\MuxPhp\Models\Asset::class);
+    expect($muxAssets[0]->getId())->toBe('8jd7M77xQgf2NzuocJRPYdSdEfY5dLlcRwFARtgQqU4');
 });

--- a/tests/Feature/MuxServiceTest.php
+++ b/tests/Feature/MuxServiceTest.php
@@ -164,7 +164,7 @@ test('sends API request to list assets', function () {
     expect($muxAssets[1]->getId())->toBe('lJ4bGGsp7ZlPf02nMg015W02iHQLN9XnuuLRBsPS00xqd68');
 });
 
-test('paginates API request to list assets', function () {
+test('paginates API request to list all assets', function () {
     $this->guzzler->expects($this->once())
         ->ray()
         ->get('https://api.mux.com/video/v1/assets')
@@ -273,7 +273,7 @@ test('paginates API request to list assets', function () {
             'data' => []
         ]);
 
-    $muxAssets = $this->service->listMuxAssets(200);
+    $muxAssets = $this->service->listMuxAssets(all: true);
 
     $this->guzzler->assertHistoryCount(3);
 


### PR DESCRIPTION
- Paginate the `List assets` endpoint to allow fetching all assets at once
- Normally, a limit of `100` assets per page is applied
- Useful in the prune command