### PR TITLE
Display correct playback id

### DIFF
--- a/resources/js/components/MuxMirrorFieldtype.vue
+++ b/resources/js/components/MuxMirrorFieldtype.vue
@@ -39,7 +39,7 @@
                             <td v-else>
                                 <ui-icon name="globals" v-tooltip="'Public Playback ID'"></ui-icon>
                             </td>
-                            <td>{{ value.id }}</td>
+                            <td>{{ id }}</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Currently, the fieldtype displays the asset id twice in place of displaying the correct playback id. This fixes that.

<img width="830" height="249" alt="Screenshot 2026-02-28 at 09 28 13" src="https://github.com/user-attachments/assets/e219218b-219e-49bc-9328-55897de659ea" />
