### PR TITLE
Asset browser filters

### DIFF
--- a/src/Fieldtypes/MuxMirrorFieldtype.php
+++ b/src/Fieldtypes/MuxMirrorFieldtype.php
@@ -6,6 +6,7 @@ use Daun\StatamicMux\Data\MuxAsset;
 use Daun\StatamicMux\GraphQL\MuxMirrorType;
 use Daun\StatamicMux\GraphQL\MuxPlaybackIdType;
 use Daun\StatamicMux\Jobs\CreateMuxAssetJob;
+use Daun\StatamicMux\Query\Scopes\Filters\Fields\MuxMirrorFieldtypeFilter;
 use Daun\StatamicMux\Support\Queue;
 use Statamic\Assets\Asset;
 use Statamic\Facades\GraphQL;
@@ -100,5 +101,10 @@ class MuxMirrorFieldtype extends Fieldtype
     {
         GraphQL::addType(MuxMirrorType::class);
         GraphQL::addType(MuxPlaybackIdType::class);
+    }
+
+    public function filter()
+    {
+        return new MuxMirrorFieldtypeFilter($this);
     }
 }

--- a/src/Query/Scopes/Filters/Fields/MuxMirrorFieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/MuxMirrorFieldtypeFilter.php
@@ -58,21 +58,21 @@ class MuxMirrorFieldtypeFilter extends FieldtypeFilter
         $field = $values['field'];
 
         if ($field === 'status') {
-            match ($values['status']) {
-                 'uploaded' => $query->whereNotNull("{$handle}->id"),
-                 'not_uploaded' => $query->whereNull("{$handle}->id"),
-                 'ignored' => $query->where('is_video', '=', false),
+            match ($values['status'] ?? null) {
+                 'uploaded' => $query->where('is_video', true)->whereNotNull("{$handle}->id"),
+                 'not_uploaded' => $query->where('is_video', true)->whereNull("{$handle}->id"),
+                 'ignored' => $query->where('is_video', false),
             };
         }
 
         if ($field === 'policy') {
-            match ($values['policy']) {
-                 'public' => $query->whereJsonContains("{$handle}->playback_ids", ['policy' => 'public']),
-                 'signed' => $query->whereJsonContains("{$handle}->playback_ids", ['policy' => 'signed']),
+            match ($values['policy'] ?? null) {
+                 'public' => $query->whereNotNull("{$handle}->playback_ids->public"),
+                 'signed' => $query->whereNotNull("{$handle}->playback_ids->signed"),
             };
         }
 
-        if ($field === 'id') {
+        if ($field === 'id' && ($values['id'] ?? null)) {
             $query->where(fn($q) => $q
                 ->where("{$handle}->id", 'like', "%{$values['id']}%")
                 ->orWhere("{$handle}->playback_ids", 'like', "%{$values['id']}%")
@@ -82,13 +82,19 @@ class MuxMirrorFieldtypeFilter extends FieldtypeFilter
 
     public function badge($values)
     {
-        $field = $this->fieldtype->field()->display();
-        $operator = $values['operator'];
-        $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
-        $value = $values['value'];
-        $translatedValue = Arr::get($this->fieldItems(), "value.options.{$value}");
+        $base = 'Mux';
+        $field = match ($values['field'] ?? null) {
+            'status' => __('Status'),
+            'policy' => __('Policy'),
+            'id' => __('ID'),
+        };
+        $value = match ($values['field'] ?? null) {
+            'status' => Arr::get($this->fieldItems(), "status.options.{$values['status']}"),
+            'policy' => Arr::get($this->fieldItems(), "policy.options.{$values['policy']}"),
+            'id' => $values['id'] ?? null,
+        };
 
-        return $field.' '.strtolower($translatedOperator).' '.$translatedValue;
+        return $base.' '.$field.' '.__('Is').' '.$value;
     }
 
     public function isComplete($values): bool

--- a/src/Query/Scopes/Filters/Fields/MuxMirrorFieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/MuxMirrorFieldtypeFilter.php
@@ -59,21 +59,21 @@ class MuxMirrorFieldtypeFilter extends FieldtypeFilter
 
         if ($field === 'status') {
             match ($values['status'] ?? null) {
-                 'uploaded' => $query->where('is_video', true)->whereNotNull("{$handle}->id"),
-                 'not_uploaded' => $query->where('is_video', true)->whereNull("{$handle}->id"),
-                 'ignored' => $query->where('is_video', false),
+                'uploaded' => $query->where('is_video', true)->whereNotNull("{$handle}->id"),
+                'not_uploaded' => $query->where('is_video', true)->whereNull("{$handle}->id"),
+                'ignored' => $query->where('is_video', false),
             };
         }
 
         if ($field === 'policy') {
             match ($values['policy'] ?? null) {
-                 'public' => $query->whereNotNull("{$handle}->playback_ids->public"),
-                 'signed' => $query->whereNotNull("{$handle}->playback_ids->signed"),
+                'public' => $query->whereNotNull("{$handle}->playback_ids->public"),
+                'signed' => $query->whereNotNull("{$handle}->playback_ids->signed"),
             };
         }
 
         if ($field === 'id' && ($values['id'] ?? null)) {
-            $query->where(fn($q) => $q
+            $query->where(fn ($q) => $q
                 ->where("{$handle}->id", 'like', "%{$values['id']}%")
                 ->orWhere("{$handle}->playback_ids", 'like', "%{$values['id']}%")
             );

--- a/src/Query/Scopes/Filters/Fields/MuxMirrorFieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/MuxMirrorFieldtypeFilter.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Daun\StatamicMux\Query\Scopes\Filters\Fields;
+
+use Illuminate\Support\Arr;
+use Statamic\Query\Scopes\Filters\Fields\FieldtypeFilter;
+
+class MuxMirrorFieldtypeFilter extends FieldtypeFilter
+{
+    public function fieldItems()
+    {
+        return [
+            'field' => [
+                'type' => 'select',
+                'options' => [
+                    'status' => __('Status'),
+                    'policy' => __('Policy'),
+                    'id' => __('ID'),
+                ],
+                'default' => 'status',
+            ],
+            'id' => [
+                'type' => 'text',
+                'placeholder' => __('ID'),
+                'required' => false,
+                'if' => [
+                    'field' => 'id',
+                ],
+            ],
+            'policy' => [
+                'type' => 'select',
+                'options' => [
+                    'public' => __('Public'),
+                    'signed' => __('Signed'),
+                ],
+                'required' => false,
+                'if' => [
+                    'field' => 'policy',
+                ],
+            ],
+            'status' => [
+                'type' => 'select',
+                'options' => [
+                    'uploaded' => __('Uploaded'),
+                    'not_uploaded' => __('Not Uploaded'),
+                    'ignored' => __('Ignored'),
+                ],
+                'required' => false,
+                'if' => [
+                    'field' => 'status',
+                ],
+            ],
+        ];
+    }
+
+    public function apply($query, $handle, $values)
+    {
+        $field = $values['field'];
+
+        if ($field === 'status') {
+            match ($values['status']) {
+                 'uploaded' => $query->whereNotNull("{$handle}->id"),
+                 'not_uploaded' => $query->whereNull("{$handle}->id"),
+                 'ignored' => $query->where('is_video', '=', false),
+            };
+        }
+
+        if ($field === 'policy') {
+            match ($values['policy']) {
+                 'public' => $query->whereJsonContains("{$handle}->playback_ids", ['policy' => 'public']),
+                 'signed' => $query->whereJsonContains("{$handle}->playback_ids", ['policy' => 'signed']),
+            };
+        }
+
+        if ($field === 'id') {
+            $query->where(fn($q) => $q
+                ->where("{$handle}->id", 'like', "%{$values['id']}%")
+                ->orWhere("{$handle}->playback_ids", 'like', "%{$values['id']}%")
+            );
+        }
+    }
+
+    public function badge($values)
+    {
+        $field = $this->fieldtype->field()->display();
+        $operator = $values['operator'];
+        $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
+        $value = $values['value'];
+        $translatedValue = Arr::get($this->fieldItems(), "value.options.{$value}");
+
+        return $field.' '.strtolower($translatedOperator).' '.$translatedValue;
+    }
+
+    public function isComplete($values): bool
+    {
+        $values = array_filter($values);
+
+        if (! $field = Arr::get($values, 'field')) {
+            return false;
+        }
+
+        if ($field === 'status' && Arr::has($values, 'status')) {
+            return true;
+        }
+
+        if ($field === 'policy' && Arr::has($values, 'policy')) {
+            return true;
+        }
+
+        if ($field === 'id' && Arr::has($values, 'id')) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Enable filtering assets by
  - Mux upload status (uploaded, not uploaded, ignored)
  - Mux playback policy (public, signed)
  - Mux ID or playback ID

<img width="948" height="234" alt="Screenshot 2026-03-18 at 22 22 45" src="https://github.com/user-attachments/assets/8972c302-ec84-420c-adac-78a700f10e21" />

<img width="872" height="227" alt="Screenshot 2026-03-18 at 22 22 19" src="https://github.com/user-attachments/assets/55b1bfc9-59c9-416e-b4a9-d7ac93a7dc92" />
