### PR TITLE
Exclude redacted private key from logs

### DIFF
--- a/src/Mux/MuxUrls.php
+++ b/src/Mux/MuxUrls.php
@@ -99,7 +99,6 @@ class MuxUrls
                 'payload' => $claims,
                 'playback_id' => $playbackId,
                 'key_id' => $this->keyId,
-                'private_key' => $this->privateKey,
             ]);
 
             return null;


### PR DESCRIPTION
- Private keys are logged redacted on errors: `sg68d5**************`
- This is safe, but still not useful
- Just remove them entirely