### PR TITLE
Ignore reserved claim names in token user params

### DIFF
--- a/src/Mux/MuxUrls.php
+++ b/src/Mux/MuxUrls.php
@@ -8,6 +8,7 @@ use Daun\StatamicMux\Facades\Log;
 use Daun\StatamicMux\Mux\Enums\MuxAudience;
 use Daun\StatamicMux\Support\URL;
 use Firebase\JWT\JWT;
+use Illuminate\Support\Arr;
 
 class MuxUrls
 {
@@ -85,12 +86,15 @@ class MuxUrls
 
         $timestamp = $this->timestamp($expiration);
 
-        $claims = array_merge([
+        // Remove reserved JWT claim names
+        $params = Arr::except($params ?? [], ['sub', 'aud' ,'exp', 'kid', 'iat', 'nbf', 'iss', 'jti']);
+
+        $claims = array_merge($params, [
             'sub' => $playbackId,
             'aud' => $audience,
             'exp' => $timestamp,
             'kid' => $this->keyId,
-        ], $params ?? []);
+        ]);
 
         try {
             return JWT::encode($claims, base64_decode($this->privateKey), 'RS256');

--- a/src/Mux/MuxUrls.php
+++ b/src/Mux/MuxUrls.php
@@ -87,7 +87,7 @@ class MuxUrls
         $timestamp = $this->timestamp($expiration);
 
         // Remove reserved JWT claim names
-        $params = Arr::except($params ?? [], ['sub', 'aud' ,'exp', 'kid', 'iat', 'nbf', 'iss', 'jti']);
+        $params = Arr::except($params ?? [], ['sub', 'aud', 'exp', 'kid', 'iat', 'nbf', 'iss', 'jti']);
 
         $claims = array_merge($params, [
             'sub' => $playbackId,

--- a/tests/Feature/MuxUrlsTest.php
+++ b/tests/Feature/MuxUrlsTest.php
@@ -61,6 +61,23 @@ test('signs urls and removes params', function () {
         ->not->toContain('width');
 });
 
+test('token ignores reserved claim names in user params', function () {
+    $tokenWithoutClaims = $this->urls->token('playback-id', MuxAudience::Thumbnail, [
+        'width' => 10,
+    ]);
+
+    $tokenWithClaims = $this->urls->token('playback-id', MuxAudience::Thumbnail, [
+        'width' => 10,
+        'sub' => 'other-playback-id',
+        'aud' => 'other-audience',
+        'exp' => 1234567890,
+        'kid' => 'other-key-id',
+    ]);
+
+    expect($tokenWithoutClaims)
+        ->toEqual($tokenWithClaims);
+});
+
 test('generates playback url', function () {
     expect(Str::containsAll($this->urls->playback('playback-id'), ['stream.mux.com', 'm3u8', 'playback-id']))->toBeTrue();
 });


### PR DESCRIPTION
- Ensure users of the `Mux::token()` method cannot smuggle in JWT claim names via the additional `$params` arg
- This is potentially unsafe in unauthenticated GraphQL contexts where the `playback_id` key can be queried
