### PR TITLE
Mask credentials in debug context

### DIFF
--- a/src/Mux/MuxApi.php
+++ b/src/Mux/MuxApi.php
@@ -70,7 +70,7 @@ class MuxApi
 
         $context = [
             'token_id' => $this->tokenId,
-            'token_secret' => $this->tokenSecret,
+            'token_secret' => $this->tokenSecret ? '(set)' : '(not set)',
             'test_mode' => $this->testMode,
         ];
 


### PR DESCRIPTION
- Mask token secret in the debug context
- We currently already scrub it down to the first 4 characters (`7df4******`)
- But better safe then sorry: the token id should be enough to debug misconfigured credentials
