### PR TITLE
fix: Mux tags pass full Antlers context to views, causing infinite augmentation recursion (500)

### DIFF
--- a/src/Tags/MuxTags.php
+++ b/src/Tags/MuxTags.php
@@ -168,8 +168,7 @@ class MuxTags extends Tags
                 fn ($attr) => $attr->merge(['autoplay' => true, 'loop' => true, 'muted' => true])
             );
 
-        $viewData = $this->context
-            ->merge($data)
+        $viewData = collect($data)
             ->merge(['script' => $this->params->bool('script', false)])
             ->merge(['lazyload' => $this->params->bool('lazyload', false)])
             ->merge(['attributes' => $this->toHtmlAttributes($htmlAttributes)])


### PR DESCRIPTION
## Summary

`MuxTags::component()` seeds the component view data with the **entire Antlers context** (`$this->context`). When that context contains an augmented entry from a **structured collection** (e.g. `pages`) and the entry references **another entry** (e.g. via a `link` or `entries` field), rendering the tag triggers an **unbounded recursion** that hangs the request until `max_execution_time` and returns **HTTP 500**.

This affects `{{ mux:video }}`, `{{ mux:player }}` and `{{ mux:embed }}`, and is present on the current `main` (also reproduced on 3.2.0 / 3.3.0).

## Symptoms

- A page that renders a Mux tag intermittently returns a 500 with `Maximum execution time of 30 seconds exceeded`.
- The fatal is logged with an unhelpful `#0 {main}` (it's a timeout, not a thrown exception).
- Hundreds of duplicated `select * from assets_meta where ... path in (...)` queries for the *same* asset during a single request.
- CPU-bound: no network/disk I/O during the hang — pure PHP recursion.

## Root cause

`component()` builds the view data like this:

```php
$viewData = $this->context        // ← the full augmented Antlers cascade
    ->merge($data)
    ->merge([...]);

return view("statamic-mux::{$view}", $viewData)->render();
```

`view($name, $viewData)` runs through Laravel's `Illuminate\View\Factory::parseData()`, which calls `->toArray()` on every `Arrayable` it receives. `$this->context` contains the current **augmented entry**, so this forces a full, eager `toArray()` of the whole page.

For a structured-collection entry, `Statamic\Structures\Page::toArray()` augments the page's tree position (`parent` / `children`). If any field on the page resolves to **another entry** in the structure, the augmentation walks:

```
Entry::toArray → Page::toArray (parent) → Entry::toArray → … → (linked entry) → Page::toArray (parent) → …
```

There is no cycle/visited guard, so on a real tree this becomes exponential/cyclic and never terminates.

### Profiler evidence

A sampled stack (poor-man's `pcntl_alarm` sampler) during the hang, ~5000 frames deep:

```
----- functions appearing most in the stack -----
  [909x] Illuminate\Support\Collection->map
  [908x] Statamic\Data\AugmentedCollection->toArray
  [226x] Statamic\Structures\Page->toEvaluatedAugmentedArray / ->toArray
...
----- origin -----
  Daun\StatamicMux\Tags\MuxTags->video()
  → MuxTags->component()
  → view(MuxTags.php:179)
  → Illuminate\View\Factory->parseData()
  → Illuminate\Support\Collection->toArray()
  → Statamic\Entries\Entry->toArray()  → recursion
```

## Reproduction

1. A `pages`-style **structured** collection.
2. A page template that renders `{{ mux:video :src="..." }}` (a hero video, etc.).
3. On that page, a field (e.g. a `link` fieldtype) that points to **another entry** in the collection.
4. Load the page → 30s hang → HTTP 500.

Removing the Mux tag, or changing the link to a plain URL string, makes the page render instantly — which is what pinned the cause to the context being passed into `view()`.

## Fix

Build the view data from the generated Mux `$data` only. The bundled views (`mux-video`, `mux-player`, `mux-embed`) consume **only** the Mux data keys plus the explicit `script` / `lazyload` / `attributes` / `playback_modifiers` / `player_query` merges — none of them read page-level variables from the context.

```diff
-        $viewData = $this->context
-            ->merge($data)
+        $viewData = collect($data)
             ->merge(['script' => $this->params->bool('script', false)])
             ->merge(['lazyload' => $this->params->bool('lazyload', false)])
             ->merge(['attributes' => $this->toHtmlAttributes($htmlAttributes)])
             ->merge(['playback_modifiers' => $this->toHtmlAttributes($playbackModifiers)])
             ->merge(['player_query' => Arr::query($playbackModifiers->merge($playerAttributes)->all())]);
```

## Verification

With the patch applied, a page that previously timed out (structured entry + Mux video + entry link) renders in **~0.65s / HTTP 200**, with the `<mux-video>` / `<mux-player>` output unchanged. The duplicated `assets_meta` queries are gone.

## Backwards compatibility

This removes page-level context variables from the data passed to the component views. The shipped views don't use them, so there's no change in output. If a project relies on page context inside a **customised/published** Mux view, that would be affected — happy to gate this behind a flag or to only strip augmentable values from the context if you'd prefer a more conservative change.
