### PR TITLE
Rename dashboard permission

### DIFF
--- a/src/Http/Controllers/Cp/ActionsController.php
+++ b/src/Http/Controllers/Cp/ActionsController.php
@@ -44,7 +44,7 @@ class ActionsController extends ActionController
     {
         $cached = $this->reconciler->getCachedRemoteAssetsIfAvailable()->keyBy(fn ($asset) => $asset->getId());
         $user = User::current();
-        $dashboardBaseUrl = $user?->can('view mux dashboard') ? $this->mux->dashboardUrl() : null; // @phpstan-ignore method.notFound
+        $dashboardBaseUrl = $user?->can('open mux dashboard') ? $this->mux->dashboardUrl() : null; // @phpstan-ignore method.notFound
 
         return $items->map(fn ($muxId) => new MuxLibraryItem(
             $muxId,

--- a/src/Http/Controllers/Cp/ListingController.php
+++ b/src/Http/Controllers/Cp/ListingController.php
@@ -61,7 +61,7 @@ class ListingController extends CpController
             'refreshEndpoint' => cp_route('mux.listing.refresh'),
             'commandEndpoint' => cp_route('mux.command'),
             'actionUrl' => cp_route('mux.actions.remote.run'),
-            'dashboardUrl' => $user?->can('view mux dashboard') ? $this->api->dashboardUrl() : null, // @phpstan-ignore method.notFound
+            'dashboardUrl' => $user?->can('open mux dashboard') ? $this->api->dashboardUrl() : null, // @phpstan-ignore method.notFound
         ]);
     }
 

--- a/src/Http/Controllers/Cp/ListingReconciler.php
+++ b/src/Http/Controllers/Cp/ListingReconciler.php
@@ -262,7 +262,7 @@ class ListingReconciler
     protected function buildLocalRows(): Collection
     {
         $user = User::current();
-        $dashboardUrl = $user?->can('view mux dashboard') ? $this->api->dashboardUrl() : null; // @phpstan-ignore method.notFound
+        $dashboardUrl = $user?->can('open mux dashboard') ? $this->api->dashboardUrl() : null; // @phpstan-ignore method.notFound
 
         return MirrorField::assets()
             ->map(function (Asset $asset) use ($user, $dashboardUrl) {
@@ -310,7 +310,7 @@ class ListingReconciler
     protected function buildRemoteRows(Collection $localIndex): Collection
     {
         $user = User::current();
-        $dashboardUrl = $user?->can('view mux dashboard') ? $this->api->dashboardUrl() : null; // @phpstan-ignore method.notFound
+        $dashboardUrl = $user?->can('open mux dashboard') ? $this->api->dashboardUrl() : null; // @phpstan-ignore method.notFound
 
         return $this->getCachedRemoteAssets()
             ->map(function ($muxAsset) use ($localIndex, $dashboardUrl) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -196,8 +196,8 @@ class ServiceProvider extends AddonServiceProvider
                         Permission::make('view mux library')
                             ->label('View Mux library')
                             ->description('Allows viewing all videos in the connected Mux library'),
-                        Permission::make('view mux dashboard')
-                            ->label('View Mux dashboard')
+                        Permission::make('open mux dashboard')
+                            ->label('Open Mux dashboard')
                             ->description('Allows opening links to the external Mux dashboard'),
                         Permission::make('delete mux assets')
                             ->label('Delete Mux assets')

--- a/tests/Feature/Cp/ListingControllerTest.php
+++ b/tests/Feature/Cp/ListingControllerTest.php
@@ -448,7 +448,7 @@ test('local api requires manage mux permission', function () {
     expect(fn () => $controller->local($request))->toThrow(AuthorizationException::class);
 });
 
-test('dashboard urls require view mux dashboard permission', function () {
+test('dashboard urls require open mux dashboard permission', function () {
     $user = User::make()->email('no-dashboard@test.com')->password('secret');
     $user->save();
 

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -44,7 +44,7 @@ test('registers mux permissions', function () {
 
     expect(Permission::get('manage mux'))->not->toBeNull();
     expect(Permission::get('view mux library'))->not->toBeNull();
-    expect(Permission::get('view mux dashboard'))->not->toBeNull();
+    expect(Permission::get('open mux dashboard'))->not->toBeNull();
     expect(Permission::get('delete mux assets'))->not->toBeNull();
     expect(Permission::get('trigger mux sync'))->not->toBeNull();
     expect(Permission::get('view mux'))->toBeNull();


### PR DESCRIPTION
- Make it more obvious what it grants
- `view` → `open`